### PR TITLE
Reverting changes that prevents drag and drop web extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
 
-    # Run each command in parallel with the same setup steps.
+    # Run each command in parallel with the same setup steps..
     strategy:
       fail-fast: false
       matrix:

--- a/benchmark/src/Root.tsx
+++ b/benchmark/src/Root.tsx
@@ -53,6 +53,8 @@ export function Root(): JSX.Element {
     return sources;
   }, []);
 
+  const [extensionLoaders] = useState(() => []);
+
   const url = new URL(window.location.href);
 
   return (
@@ -61,6 +63,7 @@ export function Root(): JSX.Element {
       deepLinks={[url.href]}
       dataSources={dataSources}
       appConfiguration={appConfiguration}
+      extensionLoaders={extensionLoaders}
     >
       <StudioApp />
     </SharedRoot>

--- a/packages/studio-base/src/SharedRoot.tsx
+++ b/packages/studio-base/src/SharedRoot.tsx
@@ -25,6 +25,7 @@ export function SharedRoot(props: ISharedRootContext & { children: JSX.Element }
     deepLinks,
     enableGlobalCss = false,
     enableLaunchPreferenceScreen,
+    extensionLoaders,
     extraProviders,
   } = props;
 
@@ -43,6 +44,7 @@ export function SharedRoot(props: ISharedRootContext & { children: JSX.Element }
                 dataSources,
                 deepLinks,
                 enableLaunchPreferenceScreen,
+                extensionLoaders,
                 extraProviders,
                 onAppBarDoubleClick,
               }}

--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -19,6 +19,7 @@ import PlayerManager from "./components/PlayerManager";
 import SendNotificationToastAdapter from "./components/SendNotificationToastAdapter";
 import StudioToastProvider from "./components/StudioToastProvider";
 import CurrentLayoutProvider from "./providers/CurrentLayoutProvider";
+import ExtensionCatalogProvider from "./providers/ExtensionCatalogProvider";
 import PanelCatalogProvider from "./providers/PanelCatalogProvider";
 import { LaunchPreference } from "./screens/LaunchPreference";
 
@@ -35,6 +36,9 @@ function contextMenuHandler(event: MouseEvent) {
 export function StudioApp(): JSX.Element {
   const {
     dataSources,
+    extensionLoaders,
+    nativeAppMenu,
+    nativeWindow,
     deepLinks,
     enableLaunchPreferenceScreen,
     extraProviders,
@@ -48,6 +52,8 @@ export function StudioApp(): JSX.Element {
     /* eslint-disable react/jsx-key */
     <TimelineInteractionStateProvider />,
     <CurrentLayoutProvider />,
+    <ExtensionCatalogProvider loaders={extensionLoaders} />,
+    <UserScriptStateProvider />,
     <PlayerManager playerSources={dataSources} />,
     <EventsProvider />,
     /* eslint-enable react/jsx-key */

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext, useContext } from "react";
-import { createStore, StoreApi, useStore } from "zustand";
+import { createContext } from "react";
+import { StoreApi, useStore } from "zustand";
 
+import { useGuaranteedContext } from "@foxglove/hooks";
 import {
   ExtensionPanelRegistration,
   Immutable,
@@ -20,10 +21,13 @@ export type RegisteredPanel = {
 };
 
 export type ExtensionCatalog = Immutable<{
+  downloadExtension: (url: string) => Promise<Uint8Array>;
   installExtension: (
     namespace: ExtensionNamespace,
     foxeFileData: Uint8Array,
   ) => Promise<ExtensionInfo>;
+  refreshExtensions: () => Promise<void>;
+  uninstallExtension: (namespace: ExtensionNamespace, id: string) => Promise<void>;
 
   installedExtensions: undefined | ExtensionInfo[];
   installedPanels: undefined | Record<string, RegisteredPanel>;
@@ -31,17 +35,11 @@ export type ExtensionCatalog = Immutable<{
   installedTopicAliasFunctions: undefined | TopicAliasFunctions;
 }>;
 
-export const ExtensionCatalogContext = createContext<StoreApi<ExtensionCatalog>>(
-  createStore(() => ({
-    installExtension: async () => await Promise.reject("Unsupported"),
-    installedExtensions: [],
-    installedPanels: {},
-    installedMessageConverters: [],
-    installedTopicAliasFunctions: [],
-  })),
+export const ExtensionCatalogContext = createContext<undefined | StoreApi<ExtensionCatalog>>(
+  undefined,
 );
 
 export function useExtensionCatalog<T>(selector: (registry: ExtensionCatalog) => T): T {
-  const context = useContext(ExtensionCatalogContext);
+  const context = useGuaranteedContext(ExtensionCatalogContext);
   return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/SharedRootContext.ts
+++ b/packages/studio-base/src/context/SharedRootContext.ts
@@ -8,11 +8,15 @@ import { AppBarProps } from "@foxglove/studio-base/components/AppBar";
 import { CustomWindowControlsProps } from "@foxglove/studio-base/components/AppBar/CustomWindowControls";
 import { IAppConfiguration } from "@foxglove/studio-base/context/AppConfigurationContext";
 import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
 
 interface ISharedRootContext {
   deepLinks: readonly string[];
   appConfiguration?: IAppConfiguration;
-  dataSources: readonly IDataSourceFactory[];
+  dataSources: IDataSourceFactory[];
+  extensionLoaders: readonly ExtensionLoader[];
+  nativeAppMenu?: INativeAppMenu;
+  nativeWindow?: INativeWindow;
   enableLaunchPreferenceScreen?: boolean;
   enableGlobalCss?: boolean;
   appBarLeftInset?: number;
@@ -25,6 +29,7 @@ interface ISharedRootContext {
 const SharedRootContext = createContext<ISharedRootContext>({
   deepLinks: [],
   dataSources: [],
+  extensionLoaders: [],
 });
 SharedRootContext.displayName = "SharedRootContext";
 

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -1,0 +1,235 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
+import { ExtensionInfo } from "@foxglove/studio-base/types/Extensions";
+
+import ExtensionCatalogProvider from "./ExtensionCatalogProvider";
+
+function fakeExtension(overrides: Partial<ExtensionInfo>): ExtensionInfo {
+  return {
+    id: "id",
+    description: "description",
+    displayName: "display name",
+    homepage: "homepage",
+    keywords: ["keyword1", "keyword2"],
+    license: "license",
+    name: "name",
+    namespace: "local",
+    publisher: "publisher",
+    qualifiedName: "qualified name",
+    version: "1",
+    ...overrides,
+  };
+}
+
+describe("ExtensionCatalogProvider", () => {
+  it("should load an extension from the loaders", async () => {
+    const source = `
+        module.exports = { activate: function() { return 1; } }
+    `;
+
+    const loadExtension = jest.fn().mockResolvedValue(source);
+    const mockPrivateLoader: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(loadExtension).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.installedExtensions).toEqual([
+      {
+        description: "description",
+        displayName: "display name",
+        homepage: "homepage",
+        id: "id",
+        keywords: ["keyword1", "keyword2"],
+        license: "license",
+        name: "sample",
+        namespace: "org",
+        publisher: "publisher",
+        qualifiedName: "qualified name",
+        version: "1",
+      },
+    ]);
+  });
+
+  it("handles extensions with the same id in different loaders", async () => {
+    const source1 = `
+        module.exports = { activate: function() { return 1; } }
+    `;
+    const source2 = `
+        module.exports = { activate: function() { return 2; } }
+    `;
+
+    const loadExtension1 = jest.fn().mockResolvedValue(source1);
+    const loadExtension2 = jest.fn().mockResolvedValue(source2);
+    const mockPrivateLoader1: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension: loadExtension1,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+    const mockPrivateLoader2: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "local", name: "sample", version: "2" })]),
+      loadExtension: loadExtension2,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader1, mockPrivateLoader2]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(loadExtension1).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(loadExtension2).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.installedExtensions).toEqual([
+      {
+        description: "description",
+        displayName: "display name",
+        homepage: "homepage",
+        id: "id",
+        keywords: ["keyword1", "keyword2"],
+        license: "license",
+        name: "sample",
+        namespace: "org",
+        publisher: "publisher",
+        qualifiedName: "qualified name",
+        version: "1",
+      },
+      {
+        description: "description",
+        displayName: "display name",
+        homepage: "homepage",
+        id: "id",
+        keywords: ["keyword1", "keyword2"],
+        license: "license",
+        name: "sample",
+        namespace: "local",
+        publisher: "publisher",
+        qualifiedName: "qualified name",
+        version: "2",
+      },
+    ]);
+  });
+
+  it("should register a message converter", async () => {
+    const source = `
+        module.exports = {
+            activate: function(ctx) {
+                ctx.registerMessageConverter({
+                    fromSchemaName: "from.Schema",
+                    toSchemaName: "to.Schema",
+                    converter: (msg) => msg,
+                })
+            }
+        }
+    `;
+
+    const loadExtension = jest.fn().mockResolvedValue(source);
+    const mockPrivateLoader: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(loadExtension).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.installedMessageConverters).toEqual([
+      {
+        fromSchemaName: "from.Schema",
+        toSchemaName: "to.Schema",
+        converter: expect.any(Function),
+        extensionNamespace: "org",
+      },
+    ]);
+  });
+
+  it("should register topic aliases", async () => {
+    const source = `
+        module.exports = {
+            activate: function(ctx) {
+                ctx.registerTopicAliases(() => {
+                    return [];
+                })
+            }
+        }
+    `;
+
+    const loadExtension = jest.fn().mockResolvedValue(source);
+    const mockPrivateLoader: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(loadExtension).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.installedTopicAliasFunctions).toEqual([
+      { extensionId: "id", aliasFunction: expect.any(Function) },
+    ]);
+  });
+});

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -1,0 +1,221 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import React, { PropsWithChildren, useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+import { StoreApi, createStore } from "zustand";
+
+import Logger from "@foxglove/log";
+import {
+  ExtensionContext,
+  ExtensionModule,
+  RegisterMessageConverterArgs,
+  TopicAliasFunction,
+} from "@foxglove/studio";
+import {
+  ExtensionCatalog,
+  ExtensionCatalogContext,
+  RegisteredPanel,
+} from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import { TopicAliasFunctions } from "@foxglove/studio-base/players/TopicAliasingPlayer/aliasing";
+import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
+import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
+
+const log = Logger.getLogger(__filename);
+
+type MessageConverter = RegisterMessageConverterArgs<unknown> & {
+  extensionNamespace?: ExtensionNamespace;
+};
+
+type ContributionPoints = {
+  panels: Record<string, RegisteredPanel>;
+  messageConverters: MessageConverter[];
+  topicAliasFunctions: TopicAliasFunctions;
+};
+
+function activateExtension(
+  extension: ExtensionInfo,
+  unwrappedExtensionSource: string,
+): ContributionPoints {
+  // registered panels stored by their fully qualified id
+  // the fully qualified id is the extension name + panel name
+  const panels: Record<string, RegisteredPanel> = {};
+
+  const messageConverters: RegisterMessageConverterArgs<unknown>[] = [];
+
+  const topicAliasFunctions: ContributionPoints["topicAliasFunctions"] = [];
+
+  log.debug(`Activating extension ${extension.qualifiedName}`);
+
+  const module = { exports: {} };
+  const require = (name: string) => {
+    return { react: React, "react-dom": ReactDOM }[name];
+  };
+
+  const extensionMode =
+    process.env.NODE_ENV === "production"
+      ? "production"
+      : process.env.NODE_ENV === "test"
+      ? "test"
+      : "development";
+
+  const ctx: ExtensionContext = {
+    mode: extensionMode,
+
+    registerPanel: (params) => {
+      log.debug(`Extension ${extension.qualifiedName} registering panel: ${params.name}`);
+
+      const fullId = `${extension.qualifiedName}.${params.name}`;
+      if (panels[fullId]) {
+        log.warn(`Panel ${fullId} is already registered`);
+        return;
+      }
+
+      panels[fullId] = {
+        extensionName: extension.qualifiedName,
+        extensionNamespace: extension.namespace,
+        registration: params,
+      };
+    },
+
+    registerMessageConverter: <Src,>(args: RegisterMessageConverterArgs<Src>) => {
+      log.debug(
+        `Extension ${extension.qualifiedName} registering message converter from: ${args.fromSchemaName} to: ${args.toSchemaName}`,
+      );
+      messageConverters.push({
+        ...args,
+        extensionNamespace: extension.namespace,
+      } as MessageConverter);
+    },
+
+    registerTopicAliases: (aliasFunction: TopicAliasFunction) => {
+      topicAliasFunctions.push({ aliasFunction, extensionId: extension.id });
+    },
+  };
+
+  try {
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    const fn = new Function("module", "require", unwrappedExtensionSource);
+
+    // load the extension module exports
+    fn(module, require, {});
+    const wrappedExtensionModule = module.exports as ExtensionModule;
+
+    wrappedExtensionModule.activate(ctx);
+  } catch (err) {
+    log.error(err);
+  }
+
+  return {
+    panels,
+    messageConverters,
+    topicAliasFunctions,
+  };
+}
+
+function createExtensionRegistryStore(
+  loaders: readonly ExtensionLoader[],
+  mockMessageConverters: readonly RegisterMessageConverterArgs<unknown>[] | undefined,
+): StoreApi<ExtensionCatalog> {
+  return createStore((set, get) => ({
+    downloadExtension: async (url: string) => {
+      const res = await fetch(url);
+      return new Uint8Array(await res.arrayBuffer());
+    },
+
+    installExtension: async (namespace: ExtensionNamespace, foxeFileData: Uint8Array) => {
+      const namespacedLoader = loaders.find((loader) => loader.namespace === namespace);
+      if (namespacedLoader == undefined) {
+        throw new Error("No extension loader found for namespace " + namespace);
+      }
+      const info = await namespacedLoader.installExtension(foxeFileData);
+      await get().refreshExtensions();
+      return info;
+    },
+
+    refreshExtensions: async () => {
+      if (loaders.length === 0) {
+        return;
+      }
+
+      const start = performance.now();
+      const extensionList: ExtensionInfo[] = [];
+      const allContributionPoints: ContributionPoints = {
+        panels: {},
+        messageConverters: [],
+        topicAliasFunctions: [],
+      };
+      for (const loader of loaders) {
+        try {
+          for (const extension of await loader.getExtensions()) {
+            try {
+              extensionList.push(extension);
+              const unwrappedExtensionSource = await loader.loadExtension(extension.id);
+              const contributionPoints = activateExtension(extension, unwrappedExtensionSource);
+              Object.assign(allContributionPoints.panels, contributionPoints.panels);
+              allContributionPoints.messageConverters.push(...contributionPoints.messageConverters);
+              allContributionPoints.topicAliasFunctions.push(
+                ...contributionPoints.topicAliasFunctions,
+              );
+            } catch (err) {
+              log.error("Error loading extension", err);
+            }
+          }
+        } catch (err) {
+          log.error("Error loading extension list", err);
+        }
+      }
+      log.info(
+        `Loaded ${extensionList.length} extensions in ${(performance.now() - start).toFixed(1)}ms`,
+      );
+      set({
+        installedExtensions: extensionList,
+        installedPanels: allContributionPoints.panels,
+        installedMessageConverters: allContributionPoints.messageConverters,
+        installedTopicAliasFunctions: allContributionPoints.topicAliasFunctions,
+      });
+    },
+
+    // If there are no loaders then we know there will not be any installed extensions
+    installedExtensions: loaders.length === 0 ? [] : undefined,
+
+    installedPanels: {},
+
+    installedMessageConverters: mockMessageConverters ?? [],
+
+    installedTopicAliasFunctions: [],
+
+    uninstallExtension: async (namespace: ExtensionNamespace, id: string) => {
+      const namespacedLoader = loaders.find((loader) => loader.namespace === namespace);
+      if (namespacedLoader == undefined) {
+        throw new Error("No extension loader found for namespace " + namespace);
+      }
+      await namespacedLoader.uninstallExtension(id);
+      await get().refreshExtensions();
+    },
+  }));
+}
+
+export default function ExtensionCatalogProvider({
+  children,
+  loaders,
+  mockMessageConverters,
+}: PropsWithChildren<{
+  loaders: readonly ExtensionLoader[];
+  mockMessageConverters?: readonly RegisterMessageConverterArgs<unknown>[];
+}>): JSX.Element {
+  const [store] = useState(createExtensionRegistryStore(loaders, mockMessageConverters));
+
+  // Request an initial refresh on first mount
+  const refreshExtensions = store.getState().refreshExtensions;
+  useEffect(() => {
+    refreshExtensions().catch((err) => {
+      log.error(err);
+    });
+  }, [refreshExtensions]);
+
+  return (
+    <ExtensionCatalogContext.Provider value={store}>{children}</ExtensionCatalogContext.Provider>
+  );
+}

--- a/packages/studio-web/src/WebRoot.tsx
+++ b/packages/studio-web/src/WebRoot.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import {
   AppBarProps,
@@ -17,6 +17,7 @@ import {
   McapLocalDataSourceFactory,
   SampleNuscenesDataSourceFactory,
   SharedRoot,
+  IdbExtensionLoader,
 } from "@foxglove/studio-base";
 
 import LocalStorageAppConfiguration from "./services/LocalStorageAppConfiguration";
@@ -38,6 +39,10 @@ export function WebRoot(props: {
       }),
     [],
   );
+  const [extensionLoaders] = useState(() => [
+    new IdbExtensionLoader("org"),
+    new IdbExtensionLoader("local"),
+  ]);
 
   const dataSources = useMemo(() => {
     const sources = [
@@ -60,6 +65,7 @@ export function WebRoot(props: {
       deepLinks={[window.location.href]}
       dataSources={dataSources}
       appConfiguration={appConfiguration}
+      extensionLoaders={extensionLoaders}
       enableGlobalCss
       extraProviders={props.extraProviders}
       AppBarComponent={props.AppBarComponent}


### PR DESCRIPTION
**User-Facing Changes**


Previously, was not possible dragging and dropping an extension on Foxglove Studio Web. The error "Failed to install extension <extension_name.foxe>: undefined" was being presented to the user. Now, when draging and dropping an extension the message "Installed extension <extension_name>" is being returned and the user is able to use it normally.


**Description**
This PR intends to revert commits done to prevent drag&drop extensions. Some other changes were also needed to address in order to keep the compatibility between the old version (mainly based on 1.72.0 tag) and the more recent version (1.86.0)



<!-- link relevant GitHub issues -->
https://github.com/foxglove/studio/pull/5634/files
