### PR TITLE
Revert extension panel remove

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -148,6 +148,7 @@
     "react-virtualized": "9.22.5",
     "react-window": "1.8.9",
     "readable-stream": "4.4.2",
+    "rehype-raw": "6.1.1",
     "reselect": "4.1.8",
     "sanitize-html": "2.11.0",
     "seedrandom": "3.0.5",

--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -23,6 +23,7 @@ import StudioToastProvider from "./components/StudioToastProvider";
 import { UserScriptStateProvider } from "./context/UserScriptStateContext";
 import CurrentLayoutProvider from "./providers/CurrentLayoutProvider";
 import ExtensionCatalogProvider from "./providers/ExtensionCatalogProvider";
+import ExtensionMarketplaceProvider from "./providers/ExtensionMarketplaceProvider";
 import PanelCatalogProvider from "./providers/PanelCatalogProvider";
 import { LaunchPreference } from "./screens/LaunchPreference";
 
@@ -55,6 +56,7 @@ export function StudioApp(): JSX.Element {
     /* eslint-disable react/jsx-key */
     <TimelineInteractionStateProvider />,
     <CurrentLayoutProvider />,
+    <ExtensionMarketplaceProvider />,
     <ExtensionCatalogProvider loaders={extensionLoaders} />,
     <UserScriptStateProvider />,
     <PlayerManager playerSources={dataSources} />,

--- a/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
-import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 
 const useStyles = makeStyles()({
@@ -44,7 +43,6 @@ export function SettingsMenu({
   const { classes } = useStyles();
   const { t } = useTranslation("appBar");
 
-  const { extensionSettings } = useAppContext();
   const { dialogActions } = useWorkspaceActions();
 
   const onSettingsClick = useCallback(
@@ -87,15 +85,13 @@ export function SettingsMenu({
         >
           {t("settings")}
         </MenuItem>
-        {extensionSettings && (
-          <MenuItem
-            onClick={() => {
-              onSettingsClick("extensions");
-            }}
-          >
-            {t("extensions")}
-          </MenuItem>
-        )}
+        <MenuItem
+          onClick={() => {
+            onSettingsClick("extensions");
+          }}
+        >
+          {t("extensions")}
+        </MenuItem>
         <Divider variant="middle" />
         <MenuItem onClick={onDocsClick}>{t("documentation")}</MenuItem>
         <MenuItem onClick={onSlackClick}>{t("joinSlackCommunity")}</MenuItem>

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -4,15 +4,70 @@
 
 import { StoryFn, StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
+import * as _ from "lodash-es";
 
+import { ExtensionInfo, ExtensionLoader } from "@foxglove/studio-base";
+import ExtensionMarketplaceContext, {
+  ExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import { AppSettingsDialog } from "./AppSettingsDialog";
 
+const installedExtensions: ExtensionInfo[] = _.range(1, 10).map((index) => ({
+  id: "publisher.storyextension",
+  name: "privatestoryextension",
+  qualifiedName: "storyextension",
+  displayName: `Private Extension Name ${index + 1}`,
+  description: "Private extension sample description",
+  publisher: "Private Publisher",
+  homepage: "https://foxglove.dev/",
+  license: "MIT",
+  version: `1.${index}`,
+  keywords: ["storybook", "testing"],
+  namespace: index % 2 === 0 ? "local" : "org",
+}));
+
+const marketplaceExtensions: ExtensionInfo[] = [
+  {
+    id: "publisher.storyextension",
+    name: "storyextension",
+    qualifiedName: "storyextension",
+    displayName: "Extension Name",
+    description: "Extension sample description",
+    publisher: "Publisher",
+    homepage: "https://foxglove.dev/",
+    license: "MIT",
+    version: "1.2.10",
+    keywords: ["storybook", "testing"],
+  },
+];
+
+const MockExtensionLoader: ExtensionLoader = {
+  namespace: "local",
+  getExtensions: async () => installedExtensions,
+  loadExtension: async (_id: string) => "",
+  installExtension: async (_foxeFileData: Uint8Array) => {
+    throw new Error("MockExtensionLoader cannot install extensions");
+  },
+  uninstallExtension: async (_id: string) => undefined,
+};
+
+const MockExtensionMarketplace: ExtensionMarketplace = {
+  getAvailableExtensions: async () => marketplaceExtensions,
+  getMarkdown: async (url: string) => `# Markdown
+Mock markdown rendering for URL [${url}](${url}).`,
+};
+
 function Wrapper(StoryComponent: StoryFn): JSX.Element {
   return (
     <WorkspaceContextProvider>
-      <StoryComponent />
+      <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+        <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
+          <StoryComponent />
+        </ExtensionMarketplaceContext.Provider>
+      </ExtensionCatalogProvider>
     </WorkspaceContextProvider>
   );
 }
@@ -69,6 +124,38 @@ export const GeneralChinese: StoryObj = {
 
 export const GeneralJapanese: StoryObj = {
   ...General,
+  parameters: { forceLanguage: "ja" },
+};
+
+export const Privacy: StoryObj = {
+  render: () => {
+    return <AppSettingsDialog open activeTab="privacy" />;
+  },
+};
+
+export const PrivacyChinese: StoryObj = {
+  ...Privacy,
+  parameters: { forceLanguage: "zh" },
+};
+
+export const PrivacyJapanese: StoryObj = {
+  ...Privacy,
+  parameters: { forceLanguage: "ja" },
+};
+
+export const Extensions: StoryObj = {
+  render: () => {
+    return <AppSettingsDialog open activeTab="extensions" />;
+  },
+};
+
+export const ExtensionsChinese: StoryObj = {
+  ...Extensions,
+  parameters: { forceLanguage: "zh" },
+};
+
+export const ExtensionsJapanese: StoryObj = {
+  ...Extensions,
   parameters: { forceLanguage: "ja" },
 };
 

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -25,10 +25,11 @@ import { MouseEvent, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
-import { AppSetting } from "@foxglove/studio-base";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
+import ExtensionsSettings from "@foxglove/studio-base/components/ExtensionsSettings";
 import FoxgloveLogoText from "@foxglove/studio-base/components/FoxgloveLogoText";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
@@ -181,7 +182,12 @@ const aboutItems = new Map<
   ],
 ]);
 
-export type AppSettingsTab = "general" | "extensions" | "experimental-features" | "about";
+export type AppSettingsTab =
+  | "general"
+  | "privacy"
+  | "extensions"
+  | "experimental-features"
+  | "about";
 
 const selectWorkspaceInitialActiveTab = (store: WorkspaceContextStore) =>
   store.dialogs.preferences.initialTab;
@@ -220,6 +226,8 @@ export function AppSettingsDialog(
     }
   };
 
+  const extensionSettingsComponent = extensionSettings ?? <ExtensionsSettings />;
+
   return (
     <Dialog {...props} fullWidth maxWidth="md" data-testid={`AppSettingsDialog--${activeTab}`}>
       <DialogTitle className={classes.dialogTitle}>
@@ -236,9 +244,8 @@ export function AppSettingsDialog(
           onChange={handleTabChange}
         >
           <Tab className={classes.tab} label={t("general")} value="general" />
-          {extensionSettings && (
-            <Tab className={classes.tab} label={t("extensions")} value="extensions" />
-          )}
+          <Tab className={classes.tab} label={t("privacy")} value="privacy" />
+          <Tab className={classes.tab} label={t("extensions")} value="extensions" />
           <Tab
             className={classes.tab}
             label={t("experimentalFeatures")}
@@ -280,15 +287,13 @@ export function AppSettingsDialog(
             </Stack>
           </section>
 
-          {extensionSettings && (
-            <section
-              className={cx(classes.tabPanel, {
-                [classes.tabPanelActive]: activeTab === "extensions",
-              })}
-            >
-              <Stack gap={2}>{extensionSettings}</Stack>
-            </section>
-          )}
+          <section
+            className={cx(classes.tabPanel, {
+              [classes.tabPanelActive]: activeTab === "extensions",
+            })}
+          >
+            <Stack gap={2}>{extensionSettingsComponent}</Stack>
+          </section>
 
           <section
             className={cx(classes.tabPanel, {

--- a/packages/studio-base/src/components/ExtensionDetails.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.stories.tsx
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import ExtensionMarketplaceContext, {
+  ExtensionMarketplace,
+  ExtensionMarketplaceDetail,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
+import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+export default {
+  title: "components/ExtensionDetails",
+  component: ExtensionDetails,
+};
+
+const MockExtensionLoader: ExtensionLoader = {
+  namespace: "local",
+  getExtensions: async () => [],
+  loadExtension: async (_id: string) => "",
+  installExtension: async (_foxeFileData: Uint8Array) => {
+    throw new Error("MockExtensionLoader cannot install extensions");
+  },
+  uninstallExtension: async (_id: string) => undefined,
+};
+
+const MockExtensionMarketplace: ExtensionMarketplace = {
+  getAvailableExtensions: async () => [],
+  getMarkdown: async (url: string) =>
+    `# Markdown
+Mock markdown rendering for URL [${url}](${url}).`,
+};
+
+const extension: ExtensionMarketplaceDetail = {
+  id: "publisher.storyextension",
+  name: "Extension Name",
+  description: "Extension sample description",
+  qualifiedName: "Qualified Extension Name",
+  publisher: "Publisher",
+  homepage: "https://foxglove.dev/",
+  license: "MIT",
+  version: "1.2.10",
+  readme: "https://foxglove.dev/storyextension/readme",
+  changelog: "https://foxglove.dev/storyextension/changelog",
+  foxe: "https://foxglove.dev/storyextension/extension.foxe",
+  keywords: ["storybook", "testing"],
+  time: {
+    modified: "2021-05-19T21:37:40.166Z",
+    created: "2012-04-17T00:38:04.350Z",
+    "0.0.2": "2012-04-17T00:38:05.679Z",
+    "2.1.0": "2021-05-19T21:37:38.037Z",
+  },
+};
+
+export const Details: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
+
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
+            <ExtensionDetails extension={extension} onClose={() => {}} installed={false} />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
+};

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -1,0 +1,198 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { Button, Link, Tab, Tabs, Typography, Divider } from "@mui/material";
+import { useSnackbar } from "notistack";
+import { useCallback, useState } from "react";
+import { useAsync, useMountedState } from "react-use";
+import { makeStyles } from "tss-react/mui";
+
+import { Immutable } from "@foxglove/studio";
+import Stack from "@foxglove/studio-base/components/Stack";
+import TextContent from "@foxglove/studio-base/components/TextContent";
+import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import {
+  ExtensionMarketplaceDetail,
+  useExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+type Props = {
+  installed: boolean;
+  extension: Immutable<ExtensionMarketplaceDetail>;
+  onClose: () => void;
+};
+
+const useStyles = makeStyles()((theme) => ({
+  backButton: {
+    marginLeft: theme.spacing(-1.5),
+    marginBottom: theme.spacing(1),
+  },
+  installButton: {
+    minWidth: 100,
+  },
+}));
+
+export function ExtensionDetails({ extension, onClose, installed }: Props): React.ReactElement {
+  const { classes } = useStyles();
+  const [isInstalled, setIsInstalled] = useState(installed);
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const isMounted = useMountedState();
+  const downloadExtension = useExtensionCatalog((state) => state.downloadExtension);
+  const installExtension = useExtensionCatalog((state) => state.installExtension);
+  const uninstallExtension = useExtensionCatalog((state) => state.uninstallExtension);
+  const marketplace = useExtensionMarketplace();
+  const { enqueueSnackbar } = useSnackbar();
+  const readmeUrl = extension.readme;
+  const changelogUrl = extension.changelog;
+  const canInstall = extension.foxe != undefined;
+  const canUninstall = extension.namespace !== "org";
+
+  const { value: readmeContent } = useAsync(
+    async () => (readmeUrl != undefined ? await marketplace.getMarkdown(readmeUrl) : ""),
+    [marketplace, readmeUrl],
+  );
+  const { value: changelogContent } = useAsync(
+    async () => (changelogUrl != undefined ? await marketplace.getMarkdown(changelogUrl) : ""),
+    [marketplace, changelogUrl],
+  );
+
+  const analytics = useAnalytics();
+
+  const install = useCallback(async () => {
+    if (!isDesktopApp()) {
+      enqueueSnackbar("Download the desktop app to use marketplace extensions.", {
+        variant: "error",
+      });
+      return;
+    }
+
+    const url = extension.foxe;
+    try {
+      if (url == undefined) {
+        throw new Error(`Cannot install extension ${extension.id}, "foxe" URL is missing`);
+      }
+      const data = await downloadExtension(url);
+      await installExtension("local", data);
+      if (isMounted()) {
+        setIsInstalled(true);
+        void analytics.logEvent(AppEvent.EXTENSION_INSTALL, { type: extension.id });
+      }
+    } catch (err) {
+      enqueueSnackbar(`Failed to download extension ${extension.id}. ${err.message}`, {
+        variant: "error",
+      });
+    }
+  }, [
+    analytics,
+    downloadExtension,
+    enqueueSnackbar,
+    extension.foxe,
+    extension.id,
+    installExtension,
+    isMounted,
+  ]);
+
+  const uninstall = useCallback(async () => {
+    await uninstallExtension(extension.namespace ?? "local", extension.id);
+    if (isMounted()) {
+      setIsInstalled(false);
+      void analytics.logEvent(AppEvent.EXTENSION_UNINSTALL, { type: extension.id });
+    }
+  }, [analytics, extension.id, extension.namespace, isMounted, uninstallExtension]);
+
+  return (
+    <Stack fullHeight flex="auto" gap={1}>
+      <div>
+        <Button
+          className={classes.backButton}
+          onClick={onClose}
+          size="small"
+          startIcon={<ChevronLeftIcon />}
+        >
+          Back
+        </Button>
+        <Typography variant="h3" fontWeight={500}>
+          {extension.name}
+        </Typography>
+      </div>
+
+      <Stack gap={1} alignItems="flex-start">
+        <Stack gap={0.5} paddingBottom={1}>
+          <Stack direction="row" gap={1} alignItems="baseline">
+            <Link
+              variant="body2"
+              color="primary"
+              href={extension.homepage}
+              target="_blank"
+              underline="hover"
+            >
+              {extension.id}
+            </Link>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+            >{`v${extension.version}`}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {extension.license}
+            </Typography>
+          </Stack>
+          <Typography variant="subtitle2" gutterBottom>
+            {extension.publisher}
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            {extension.description}
+          </Typography>
+        </Stack>
+        {isInstalled && canUninstall ? (
+          <Button
+            className={classes.installButton}
+            size="small"
+            key="uninstall"
+            color="inherit"
+            variant="contained"
+            onClick={uninstall}
+          >
+            Uninstall
+          </Button>
+        ) : (
+          canInstall && (
+            <Button
+              className={classes.installButton}
+              size="small"
+              key="install"
+              color="inherit"
+              variant="contained"
+              onClick={install}
+            >
+              Install
+            </Button>
+          )
+        )}
+      </Stack>
+
+      <Stack paddingTop={2} style={{ marginLeft: -16, marginRight: -16 }}>
+        <Tabs
+          textColor="inherit"
+          value={activeTab}
+          onChange={(_event, newValue: number) => {
+            setActiveTab(newValue);
+          }}
+        >
+          <Tab disableRipple label="README" value={0} />
+          <Tab disableRipple label="CHANGELOG" value={1} />
+        </Tabs>
+        <Divider />
+      </Stack>
+
+      <Stack flex="auto" paddingY={2}>
+        {activeTab === 0 && <TextContent>{readmeContent}</TextContent>}
+        {activeTab === 1 && <TextContent>{changelogContent}</TextContent>}
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { StoryObj } from "@storybook/react";
+import { useState } from "react";
+
+import { ExtensionInfo, ExtensionLoader } from "@foxglove/studio-base";
+import ExtensionsSettings from "@foxglove/studio-base/components/ExtensionsSettings";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import ExtensionMarketplaceContext, {
+  ExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+export default {
+  title: "components/ExtensionsSettings",
+  component: ExtensionsSettings,
+};
+
+const installedExtensions: ExtensionInfo[] = [
+  {
+    id: "publisher.storyextension",
+    name: "privatestoryextension",
+    qualifiedName: "storyextension",
+    displayName: "Private Extension Name",
+    description: "Private extension sample description",
+    publisher: "Private Publisher",
+    homepage: "https://foxglove.dev/",
+    license: "MIT",
+    version: "1.2.10",
+    keywords: ["storybook", "testing"],
+    namespace: "org",
+  },
+  {
+    id: "publisher.storyextension",
+    name: "storyextension",
+    qualifiedName: "storyextension",
+    displayName: "Extension Name",
+    description: "Extension sample description",
+    publisher: "Publisher",
+    homepage: "https://foxglove.dev/",
+    license: "MIT",
+    version: "1.2.10",
+    keywords: ["storybook", "testing"],
+    namespace: "local",
+  },
+];
+
+const marketplaceExtensions: ExtensionInfo[] = [
+  {
+    id: "publisher.storyextension",
+    name: "storyextension",
+    qualifiedName: "storyextension",
+    displayName: "Extension Name",
+    description: "Extension sample description",
+    publisher: "Publisher",
+    homepage: "https://foxglove.dev/",
+    license: "MIT",
+    version: "1.2.10",
+    keywords: ["storybook", "testing"],
+  },
+];
+
+const MockExtensionLoader: ExtensionLoader = {
+  namespace: "local",
+  getExtensions: async () => installedExtensions,
+  loadExtension: async (_id: string) => "",
+  installExtension: async (_foxeFileData: Uint8Array) => {
+    throw new Error("MockExtensionLoader cannot install extensions");
+  },
+  uninstallExtension: async (_id: string) => undefined,
+};
+
+const MockExtensionMarketplace: ExtensionMarketplace = {
+  getAvailableExtensions: async () => marketplaceExtensions,
+  getMarkdown: async (url: string) => `# Markdown
+Mock markdown rendering for URL [${url}](${url}).`,
+};
+
+export const Sidebar: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
+
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
+            <ExtensionsSettings />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
+};
+
+export const WithoutNetwork: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
+
+    const marketPlace = {
+      ...MockExtensionMarketplace,
+      getAvailableExtensions: () => {
+        throw new Error("offline");
+      },
+    };
+
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={marketPlace}>
+            <ExtensionsSettings />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
+};

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -1,0 +1,227 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  Alert,
+  AlertTitle,
+  Button,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import * as _ from "lodash-es";
+import { useEffect, useMemo, useState } from "react";
+import { useAsyncFn } from "react-use";
+import { makeStyles } from "tss-react/mui";
+
+import Log from "@foxglove/log";
+import { Immutable } from "@foxglove/studio";
+import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
+import Stack from "@foxglove/studio-base/components/Stack";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import {
+  ExtensionMarketplaceDetail,
+  useExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+
+const log = Log.getLogger(__filename);
+
+const useStyles = makeStyles()((theme) => ({
+  listItemButton: {
+    "&:hover": { color: theme.palette.primary.main },
+  },
+}));
+
+function displayNameForNamespace(namespace: string): string {
+  switch (namespace) {
+    case "org":
+      return "Organization";
+    default:
+      return namespace;
+  }
+}
+
+function ExtensionListEntry(props: {
+  entry: Immutable<ExtensionMarketplaceDetail>;
+  onClick: () => void;
+}): JSX.Element {
+  const {
+    entry: { id, description, name, publisher, version },
+    onClick,
+  } = props;
+  const { classes } = useStyles();
+  return (
+    <ListItem disablePadding key={id}>
+      <ListItemButton className={classes.listItemButton} onClick={onClick}>
+        <ListItemText
+          disableTypography
+          primary={
+            <Stack direction="row" alignItems="baseline" gap={0.5}>
+              <Typography variant="subtitle2" fontWeight={600}>
+                {name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {version}
+              </Typography>
+            </Stack>
+          }
+          secondary={
+            <Stack gap={0.5}>
+              <Typography variant="body2" color="text.secondary">
+                {description}
+              </Typography>
+              <Typography color="text.primary" variant="body2">
+                {publisher}
+              </Typography>
+            </Stack>
+          }
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+}
+
+export default function ExtensionsSettings(): React.ReactElement {
+  const [focusedExtension, setFocusedExtension] = useState<
+    | {
+        installed: boolean;
+        entry: Immutable<ExtensionMarketplaceDetail>;
+      }
+    | undefined
+  >(undefined);
+  const installed = useExtensionCatalog((state) => state.installedExtensions);
+  const marketplace = useExtensionMarketplace();
+
+  const [marketplaceEntries, refreshMarketplaceEntries] = useAsyncFn(
+    async () => await marketplace.getAvailableExtensions(),
+    [marketplace],
+  );
+
+  const marketplaceMap = useMemo(
+    () => _.keyBy(marketplaceEntries.value ?? [], (entry) => entry.id),
+    [marketplaceEntries],
+  );
+
+  const installedEntries = useMemo(
+    () =>
+      (installed ?? []).map((entry) => {
+        const marketplaceEntry = marketplaceMap[entry.id];
+        if (marketplaceEntry != undefined) {
+          return { ...marketplaceEntry, namespace: entry.namespace };
+        }
+
+        return {
+          id: entry.id,
+          installed: true,
+          name: entry.displayName,
+          displayName: entry.displayName,
+          description: entry.description,
+          publisher: entry.publisher,
+          homepage: entry.homepage,
+          license: entry.license,
+          version: entry.version,
+          keywords: entry.keywords,
+          namespace: entry.namespace,
+          qualifiedName: entry.qualifiedName,
+        };
+      }),
+    [installed, marketplaceMap],
+  );
+
+  const namespacedEntries = useMemo(
+    () => _.groupBy(installedEntries, (entry) => entry.namespace),
+    [installedEntries],
+  );
+
+  // Hide installed extensions from the list of available extensions
+  const filteredMarketplaceEntries = useMemo(
+    () =>
+      _.differenceWith(
+        marketplaceEntries.value ?? [],
+        installed ?? [],
+        (a, b) => a.id === b.id && a.namespace === b.namespace,
+      ),
+    [marketplaceEntries, installed],
+  );
+
+  useEffect(() => {
+    refreshMarketplaceEntries().catch((error) => {
+      log.error(error);
+    });
+  }, [refreshMarketplaceEntries]);
+
+  if (focusedExtension != undefined) {
+    return (
+      <ExtensionDetails
+        installed={focusedExtension.installed}
+        extension={focusedExtension.entry}
+        onClose={() => {
+          setFocusedExtension(undefined);
+        }}
+      />
+    );
+  }
+
+  return (
+    <Stack gap={1}>
+      {marketplaceEntries.error && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" onClick={async () => await refreshMarketplaceEntries()}>
+              Retry
+            </Button>
+          }
+        >
+          <AlertTitle>Failed to retrieve the list of available marketplace extensions</AlertTitle>
+          Check your internet connection and try again.
+        </Alert>
+      )}
+      {!_.isEmpty(namespacedEntries) ? (
+        Object.entries(namespacedEntries).map(([namespace, entries]) => (
+          <List key={namespace}>
+            <Stack paddingY={0.25} paddingX={2}>
+              <Typography component="li" variant="overline" color="text.secondary">
+                {displayNameForNamespace(namespace)}
+              </Typography>
+            </Stack>
+            {entries.map((entry) => (
+              <ExtensionListEntry
+                key={`${entry.id}`}
+                entry={entry}
+                onClick={() => {
+                  setFocusedExtension({ installed: true, entry });
+                }}
+              />
+            ))}
+          </List>
+        ))
+      ) : (
+        <List>
+          <ListItem>
+            <ListItemText primary="No installed extensions" />
+          </ListItem>
+        </List>
+      )}
+      <List>
+        <Stack paddingY={0.25} paddingX={2}>
+          <Typography component="li" variant="overline" color="text.secondary">
+            Available
+          </Typography>
+        </Stack>
+        {filteredMarketplaceEntries.map((entry) => (
+          <ExtensionListEntry
+            key={`${entry.id}_${entry.namespace}`}
+            entry={entry}
+            onClick={() => {
+              setFocusedExtension({ installed: false, entry });
+            }}
+          />
+        ))}
+      </List>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/components/TextContent.tsx
+++ b/packages/studio-base/src/components/TextContent.tsx
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Link } from "@mui/material";
+import { PropsWithChildren, CSSProperties, useCallback, useContext } from "react";
+import Markdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import { makeStyles } from "tss-react/mui";
+
+import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext";
+
+const useStyles = makeStyles()(({ palette, shape, spacing, typography, shadows }) => {
+  return {
+    root: {
+      fontFamily: typography.body2.fontFamily,
+      fontSize: typography.body2.fontSize,
+      fontWeight: typography.body2.fontWeight,
+      lineHeight: typography.body2.lineHeight,
+      backgroundColor: "transparent",
+      color: palette.text.secondary,
+
+      "h1, h2, h3, h4, h5, h6": {
+        color: palette.text.primary,
+
+        "&:first-child": { marginTop: 0 },
+      },
+      h1: {
+        fontFamily: typography.h4.fontFamily,
+        fontSize: typography.h4.fontSize,
+        lineHeight: typography.h4.lineHeight,
+        marginBottom: spacing(1),
+        fontWeight: 500,
+      },
+      h2: {
+        fontFamily: typography.h5.fontFamily,
+        fontSize: typography.h5.fontSize,
+        lineHeight: typography.h5.lineHeight,
+        marginBottom: spacing(1),
+        fontWeight: 500,
+      },
+      h3: {
+        fontFamily: typography.h6.fontFamily,
+        fontSize: typography.h6.fontSize,
+        lineHeight: typography.h6.lineHeight,
+        marginBottom: spacing(1),
+        color: palette.text.secondary,
+        fontWeight: 500,
+      },
+      h4: {
+        fontFamily: typography.subtitle1.fontFamily,
+        fontSize: typography.subtitle1.fontSize,
+        lineHeight: typography.subtitle1.lineHeight,
+        marginBottom: spacing(0.5),
+        color: palette.text.secondary,
+        fontWeight: 500,
+      },
+      "h5, h6": {
+        fontFamily: typography.body1.fontFamily,
+        fontSize: typography.body1.fontSize,
+        lineHeight: typography.body1.lineHeight,
+        marginBottom: spacing(0.5),
+        color: palette.text.secondary,
+        fontWeight: 500,
+      },
+      "ol, ul": {
+        paddingLeft: spacing(2.5),
+        marginBottom: spacing(2.5),
+      },
+      li: {
+        margin: spacing(0.5, 0),
+      },
+      "b, strong": {
+        fontWeight: "700 !important",
+      },
+      "p, ul": {
+        margin: spacing(1, 0),
+
+        "&:only-child": {
+          margin: spacing(0.5, 0),
+        },
+      },
+      img: {
+        maxWidth: "100%",
+      },
+      pre: {
+        whiteSpace: "pre-wrap",
+        fontFamily: typography.fontMonospace,
+        backgroundColor: palette.action.hover,
+        padding: spacing(0, 0.5),
+        borderRadius: shadows[2],
+
+        code: {
+          backgroundColor: "transparent",
+          padding: 0,
+        },
+      },
+      code: {
+        fontFamily: typography.fontMonospace,
+        backgroundColor: palette.action.hover,
+        borderRadius: "0.2em",
+        padding: spacing(0, 0.5),
+      },
+      kbd: {
+        display: "inline-flex",
+        flex: "none",
+        fontFamily: typography.fontMonospace,
+        color: palette.text.secondary,
+        backgroundColor: palette.background.default,
+        boxShadow: `inset 0 1px 0 ${palette.action.hover}`,
+        borderRadius: shape.borderRadius,
+        fontSize: typography.body2.fontSize,
+        padding: spacing(0, 0.5),
+        fontWeight: 500,
+        minWidth: 20,
+        alignItems: "center",
+        justifyContent: "center",
+      },
+      table: {
+        borderCollapse: "collapse",
+        borderSpacing: 0,
+        margin: spacing(1, -0.5),
+        border: `1px solid ${palette.divider}`,
+      },
+      "td, th": {
+        padding: spacing(0.5),
+        borderBottom: `1px solid ${palette.divider}`,
+        borderRight: `1px solid ${palette.divider}`,
+
+        "&:last-child": {
+          borderRight: "none",
+        },
+      },
+      th: {
+        whiteSpace: "nowrap",
+      },
+      tr: {
+        "&:last-child": {
+          "td, th": { borderBottom: "none" },
+        },
+      },
+    },
+  };
+});
+
+type Props = {
+  style?: CSSProperties;
+  allowMarkdownHtml?: boolean;
+};
+
+export default function TextContent(
+  props: PropsWithChildren<Props>,
+): React.ReactElement | ReactNull {
+  const { children, style, allowMarkdownHtml } = props;
+  const { classes } = useStyles();
+  const handleLink = useContext(LinkHandlerContext);
+
+  const linkRenderer = useCallback(
+    (linkProps: { href?: string; children: React.ReactNode }) => {
+      return (
+        <Link
+          color="primary"
+          underline="hover"
+          variant="inherit"
+          href={linkProps.href}
+          rel="noopener noreferrer"
+          onClick={(event) => {
+            handleLink(event, linkProps.href ?? "");
+          }}
+          target="_blank"
+        >
+          {linkProps.children}
+        </Link>
+      );
+    },
+    [handleLink],
+  );
+
+  return (
+    <div className={classes.root} style={style}>
+      {typeof children === "string" ? (
+        <Markdown
+          rehypePlugins={allowMarkdownHtml === true ? [rehypeRaw] : []}
+          components={{ a: linkRenderer }}
+        >
+          {children}
+        </Markdown>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
+++ b/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext } from "react";
+
+import { ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
+
+export type ExtensionMarketplaceDetail = {
+  id: string;
+  name: string;
+  qualifiedName: string;
+  namespace?: ExtensionNamespace;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  readme?: string;
+  changelog?: string;
+  sha256sum?: string;
+  foxe?: string;
+  keywords?: string[];
+  time?: Record<string, string>;
+};
+
+export interface ExtensionMarketplace {
+  getAvailableExtensions(): Promise<ExtensionMarketplaceDetail[]>;
+  getMarkdown(url: string): Promise<string>;
+}
+
+const ExtensionMarketplaceContext = createContext<ExtensionMarketplace | undefined>(undefined);
+ExtensionMarketplaceContext.displayName = "ExtensionMarketplaceContext";
+
+export default ExtensionMarketplaceContext;

--- a/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
+++ b/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 
 import { ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 
@@ -31,5 +31,15 @@ export interface ExtensionMarketplace {
 
 const ExtensionMarketplaceContext = createContext<ExtensionMarketplace | undefined>(undefined);
 ExtensionMarketplaceContext.displayName = "ExtensionMarketplaceContext";
+
+export function useExtensionMarketplace(): ExtensionMarketplace {
+  const extensionMarketplace = useContext(ExtensionMarketplaceContext);
+  if (extensionMarketplace == undefined) {
+    throw new Error(
+      "An ExtensionMarketplaceContext provider is required to useExtensionMarketplace",
+    );
+  }
+  return extensionMarketplace;
+}
 
 export default ExtensionMarketplaceContext;

--- a/packages/studio-base/src/context/LinkHandlerContext.ts
+++ b/packages/studio-base/src/context/LinkHandlerContext.ts
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { createContext } from "react";
+
+// This context provides a function that handles link clicks, for example to handle app-internal
+// links by showing a modal dialog rather than actualy navigating.
+const LinkHandlerContext = createContext<(event: React.MouseEvent, href: string) => void>(() => {});
+LinkHandlerContext.displayName = "LinkHandlerContext";
+
+export default LinkHandlerContext;

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -25,6 +25,7 @@ export const appSettings = {
   newAppMenuDescription: "Show the new menu and navigation.",
   noExperimentalFeatures: "Currently there are no experimental features.",
   openLinksIn: "Open links in",
+  privacy: "Privacy",
   ros: "ROS",
   settings: "Settings",
   timestampFormat: "Timestamp format",

--- a/packages/studio-base/src/providers/ExtensionMarketplaceProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionMarketplaceProvider.tsx
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback } from "react";
+
+import { useShallowMemo } from "@foxglove/hooks";
+import ExtensionMarketplaceContext, {
+  ExtensionMarketplaceDetail,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+
+const MARKETPLACE_URL =
+  "https://raw.githubusercontent.com/foxglove/studio-extension-marketplace/main/extensions.json";
+
+export default function ExtensionMarketplaceProvider({
+  children,
+}: React.PropsWithChildren): JSX.Element {
+  const getAvailableExtensions = useCallback(async (): Promise<ExtensionMarketplaceDetail[]> => {
+    const res = await fetch(MARKETPLACE_URL);
+    return (await res.json()) as ExtensionMarketplaceDetail[];
+  }, []);
+  const getMarkdown = useCallback(async (url: string): Promise<string> => {
+    const res = await fetch(url);
+    return await res.text();
+  }, []);
+  const marketplace = useShallowMemo({
+    getAvailableExtensions,
+    getMarkdown,
+  });
+  return (
+    <ExtensionMarketplaceContext.Provider value={marketplace}>
+      {children}
+    </ExtensionMarketplaceContext.Provider>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,10 +2618,12 @@ __metadata:
     hammerjs: 2.0.8
     i18next: 23.7.18
     i18next-browser-languagedetector: 7.1.0
+    idb: 7.1.1
     idb-keyval: 6.2.1
     immer: 10.0.2
     intervals-fn: 3.0.3
     jest-canvas-mock: 2.5.2
+    jszip: 3.10.0
     leaflet: 1.9.4
     leaflet-ellipse: 0.9.1
     lodash-es: 4.17.21
@@ -2655,6 +2657,7 @@ __metadata:
     react-virtualized: 9.22.5
     react-window: 1.8.9
     readable-stream: 4.4.2
+    rehype-raw: 6.1.1
     reselect: 4.1.8
     sanitize-html: 2.11.0
     seedrandom: 3.0.5
@@ -12171,6 +12174,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-to-hyperscript@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "hast-to-hyperscript@npm:10.0.1"
+  dependencies:
+    "@types/unist": ^2.0.0
+    comma-separated-tokens: ^2.0.0
+    property-information: ^6.0.0
+    space-separated-tokens: ^2.0.0
+    style-to-object: ^0.3.0
+    unist-util-is: ^5.0.0
+    web-namespaces: ^2.0.0
+  checksum: 0ec7a6f873312421c6cfa84f8c842fa00c74e96018c371ace4800fda6590e208db8e31d4e84b09e436fe6b9b87b2fd2968b30c27881ff82fc9fe466a0f59b922
+  languageName: node
+  linkType: hard
+
 "hast-util-from-html@npm:^2.0.0":
   version: 2.0.1
   resolution: "hast-util-from-html@npm:2.0.1"
@@ -12235,6 +12253,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-raw@npm:^7.2.0":
+  version: 7.2.1
+  resolution: "hast-util-raw@npm:7.2.1"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/parse5": ^6.0.0
+    hast-util-from-parse5: ^7.0.0
+    hast-util-to-parse5: ^7.0.0
+    html-void-elements: ^2.0.0
+    parse5: ^6.0.0
+    unist-util-position: ^4.0.0
+    unist-util-visit: ^4.0.0
+    vfile: ^5.0.0
+    web-namespaces: ^2.0.0
+    zwitch: ^2.0.0
+  checksum: 344f8f27a45d778d399f34068027ae4c1104445beb2ac61762c762b1b7c438e88ebc29b5da0042f16ee325fa9cacec1b755be44027acc4a5f581f944f758c0be
+  languageName: node
+  linkType: hard
+
 "hast-util-raw@npm:^9.0.0":
   version: 9.0.2
   resolution: "hast-util-raw@npm:9.0.2"
@@ -12273,6 +12310,20 @@ __metadata:
     stringify-entities: ^4.0.0
     zwitch: ^2.0.4
   checksum: 62d5805edaa4e4ee72d77b8276a95cf6cf380631e20a3be2301f89dbe51d53a079a8a1390ce253927c18efdbd1fed0d93f65cd34e107d3cded296ec3e8c0a45b
+  languageName: node
+  linkType: hard
+
+"hast-util-to-parse5@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "hast-util-to-parse5@npm:7.0.0"
+  dependencies:
+    "@types/hast": ^2.0.0
+    "@types/parse5": ^6.0.0
+    hast-to-hyperscript: ^10.0.0
+    property-information: ^6.0.0
+    web-namespaces: ^2.0.0
+    zwitch: ^2.0.0
+  checksum: a30ceaca3f456b0a4c8d8330d782d9bcf7e05abe362b2cf208b204afeaef155d580ed84c959c0ef719edeac413e04759000f3e3318816aea41e7841876e5f890
   languageName: node
   linkType: hard
 
@@ -12466,6 +12517,13 @@ __metadata:
   version: 3.1.0
   resolution: "html-tags@npm:3.1.0"
   checksum: 67587f2d4022390d7bc34b1313773ecb0b0e0c79fb331aa3e20023eb4c862c7188a1ff775d126fcd75f4e4f08f956666a1c57688c4d24d85a77f9d4b1a42f345
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "html-void-elements@npm:2.0.1"
+  checksum: 06d41f13b9d5d6e0f39861c4bec9a9196fa4906d56cd5cf6cf54ad2e52a85bf960cca2bf9600026bde16c8331db171bedba5e5a35e2e43630c8f1d497b2fb658
   languageName: node
   linkType: hard
 
@@ -12713,6 +12771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"idb@npm:7.1.1":
+  version: 7.1.1
+  resolution: "idb@npm:7.1.1"
+  checksum: 1973c28d53c784b177bdef9f527ec89ec239ec7cf5fcbd987dae75a16c03f5b7dfcc8c6d3285716fd0309dd57739805390bd9f98ce23b1b7d8849a3b52de8d56
+  languageName: node
+  linkType: hard
+
 "ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -12724,6 +12789,13 @@ __metadata:
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
+  languageName: node
+  linkType: hard
+
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
   languageName: node
   linkType: hard
 
@@ -14218,6 +14290,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:3.10.0":
+  version: 3.10.0
+  resolution: "jszip@npm:3.10.0"
+  dependencies:
+    lie: ~3.3.0
+    pako: ~1.0.2
+    readable-stream: ~2.3.6
+    setimmediate: ^1.0.5
+  checksum: 80cc8e0e466467e9e21447f604f9262509b29a9c65170a3fee415ac0a403beb370840973cdc17f75d2b92ab3e60685f94d267706510d46bed2dd14858a38e459
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.2":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -14308,6 +14392,15 @@ __metadata:
   bin:
     license-checker: ./bin/license-checker
   checksum: deaabf56b471cfcd7bda190753becf2589c1fede585f21160f1c3bdcff255ef013401bdeaeb6ddcfde796ed4d03612508a6338b2465132205aaf73df45c9c2b5
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: ~3.0.5
+  checksum: 33102302cf19766f97919a6a98d481e01393288b17a6aa1f030a3542031df42736edde8dab29ffdbf90bebeffc48c761eb1d064dc77592ca3ba3556f9fe6d2a8
   languageName: node
   linkType: hard
 
@@ -16032,7 +16125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pako@npm:~1.0.5":
+"pako@npm:~1.0.2, pako@npm:~1.0.5":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
   checksum: 1be2bfa1f807608c7538afa15d6f25baa523c30ec870a3228a89579e474a4d992f4293859524e46d5d87fd30fa17c5edf34dbef0671251d9749820b488660b16
@@ -17684,6 +17777,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rehype-raw@npm:6.1.1":
+  version: 6.1.1
+  resolution: "rehype-raw@npm:6.1.1"
+  dependencies:
+    "@types/hast": ^2.0.0
+    hast-util-raw: ^7.2.0
+    unified: ^10.0.0
+  checksum: a1f9d309e609f49fb1f1e06e722705f4dd2e569653a89f756eaccb33b612cf1bb511216a81d10a619d11d047afc161e4b3cb99b957df05a8ba8fdbd5843f949a
+  languageName: node
+  linkType: hard
+
 "rehype-stringify@npm:^10.0.0":
   version: 10.0.0
   resolution: "rehype-stringify@npm:10.0.0"
@@ -18306,6 +18410,13 @@ __metadata:
   version: 1.0.1
   resolution: "set-harmonic-interval@npm:1.0.1"
   checksum: c122b831c2e0b1fb812e5e9d065094b9d174bd0576f9a779ab7a7d8881c8f6dd7d5fcab9a2553da15eea670eb598f9dd4d5162b626d45cc9c529706aa1444a84
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: c9a6f2c5b51a2dabdc0247db9c46460152ffc62ee139f3157440bd48e7c59425093f42719ac1d7931f054f153e2d26cf37dfeb8da17a794a58198a2705e527fd
   languageName: node
   linkType: hard
 
@@ -18967,6 +19078,15 @@ __metadata:
   peerDependencies:
     webpack: ^5.0.0
   checksum: f59c953f56f6a935bd6a1dfa409f1128fed2b66b48ce4a7a75b85862a7156e5e90ab163878962762f528ec4d510903d828da645e143fbffd26f055dc1c094078
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "style-to-object@npm:0.3.0"
+  dependencies:
+    inline-style-parser: 0.1.1
+  checksum: 4d7084015207f2a606dfc10c29cb5ba569f2fe8005551df7396110dd694d6ff650f2debafa95bd5d147dfb4ca50f57868e2a7f91bf5d11ef734fe7ccbd7abf59
   languageName: node
   linkType: hard
 
@@ -21085,7 +21205,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zwitch@npm:^2.0.0, zwitch@npm:^2.0.4":
+"zwitch@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "zwitch@npm:2.0.2"
+  checksum: 8edd7af8375f12f64d8dbef815af32cd77bd9237d0b013210ba4e3aef25fdc460fe264cd0a19deabe9f86ef0c607240ebac1a336bf4a70bf06ef53e0652de116
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.4":
   version: 2.0.4
   resolution: "zwitch@npm:2.0.4"
   checksum: f22ec5fc2d5f02c423c93d35cdfa83573a3a3bd98c66b927c368ea4d0e7252a500df2a90a6b45522be536a96a73404393c958e945fdba95e6832c200791702b6


### PR DESCRIPTION
In the main version of foxglove studio, when running the web version locally using the command `yarn web:serve` the extension panel is no longer being displayed. It was removed by some commits done between the 1.76.0 and 1.77.0 version.
This PR was created to put back again this menu cause it's being very frequently used by the Foxglove community on BMW.

 
![image](https://github.com/foxglove/studio/assets/144259784/4e3ae7c7-4f5b-4046-abcc-edc0bb61cb07)
